### PR TITLE
CI: Fix macOS arm64 builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,8 @@ jobs:
       run: |
         cmake -S cmake/test -B cmake_config_build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }}
+          -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} \
+          ${{ matrix.platform.cmake-flags }}
         cmake --build cmake_config_build --verbose
     - name: Distcheck (Autotools)
       if: matrix.platform.autotools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         - { name: Linux (CMake),            os: ubuntu-20.04,   shell: sh }
         - { name: Linux (autotools),        os: ubuntu-20.04,   shell: sh,    autotools: true }
         - { name: MacOS x64 (CMake),        os: macos-latest,   shell: sh,    cmake-flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 }
-        - { name: MacOS arm64 (CMake),      os: macos-latest,   shell: sh,    cmake-flags: -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: MacOS arm64 (CMake),      os: macos-latest,   shell: sh,    cmake-flags: -DCMAKE_OSX_ARCHITECTURES=arm64, not-runnable: true }
         - { name: MacOS (autotools),        os: macos-latest,   shell: sh,    autotools: true }
 
     steps:
@@ -116,7 +116,7 @@ jobs:
       run: |
         cmake --build build/ --config Release --verbose --parallel
     - name: Run build-time tests (CMake)
-      if: "! matrix.platform.autotools"
+      if: "! matrix.platform.autotools && ! matrix.platform.not-runnable"
       run: |
         set -eu
         export SDL_TESTS_QUICK=1


### PR DESCRIPTION
- Do not attempt to run tests
- Add the arch flag to the config file check step